### PR TITLE
[webp] Add MAGICKCORE_WEBPMUX_DELEGATE define

### DIFF
--- a/webp/Config.txt
+++ b/webp/Config.txt
@@ -21,3 +21,4 @@ _WEBPLIB_
   Define to use the WebP library
 */
 #define MAGICKCORE_WEBP_DELEGATE
+#define MAGICKCORE_WEBPMUX_DELEGATE


### PR DESCRIPTION
I've noticed that Windows builds don't copy metadata over when encoding to **webp** format. That's caused by using  `Config.txt` for defines and not using `configure.ac`. Defining `MAGICKCORE_WEBPMUX_DELEGATE `is safe since we always build **libwebp** from source and thus always have **libwebpmux**.
I've tested **Q8 x64** build only and seems to be working OK. Sadly Windows 10 _17763_ don't understand EXIF in webp files, but converting the webp file to jpg confirms that EXIF data is present. Just to mention that Windows build of `ExifTool` _11.32_ also doesn't understand EXIF data in webp files, but `exiv2` _0.27.0_ works as expected.