### PR TITLE
Update due to tiff change

### DIFF
--- a/tiff/Config.txt
+++ b/tiff/Config.txt
@@ -31,6 +31,8 @@ tif_vms.c
 tif_win3.c
 getopt.c
 lfind.c
+strtol.c
+strtoll.c
 strtoul.c
 strtoull.c
 strcasecmp.c


### PR DESCRIPTION
I am using Visual Studio 2019 and latest Windows SDK (10.0) to compile ImageMagick.
Not excluding these two files will cause an error (duplicated symbol `strtol`) when linking on my PC.