### PR TITLE
fix cannot target anything older than VS2019

### DIFF
--- a/configure/Pages/TargetPage.cpp
+++ b/configure/Pages/TargetPage.cpp
@@ -241,6 +241,6 @@ void TargetPage::setVisualStudioVersion()
   else if (!getEnvironmentVariable(L"VS100COMNTOOLS").empty())
     _visualStudioVersion=VS2010;
   else
-    _visualStudioVersion=VSLATEST;
+    _visualStudioVersion=VSEARLIEST;
 }
 

--- a/configure/Project.cpp
+++ b/configure/Project.cpp
@@ -279,7 +279,7 @@ Project::Project(wstring name)
   _useNasm=false;
   _useUnicode=false;
   _warningLevel=0;
-  _visualStudioVersion=VSLATEST;
+  _visualStudioVersion=VSEARLIEST;
 }
 
 void Project::addLines(wifstream &config,wstring &value)

--- a/configure/ProjectFile.cpp
+++ b/configure/ProjectFile.cpp
@@ -73,7 +73,7 @@ vector<wstring> &ProjectFile::aliases()
 
 void ProjectFile::initialize(Project* project)
 {
-  _visualStudioVersion=VSLATEST;
+  _visualStudioVersion=VSEARLIEST;
   setFileName();
   _guid=createGuid();
 

--- a/configure/Shared.h
+++ b/configure/Shared.h
@@ -31,7 +31,7 @@ enum {UNDEFINEDTYPE, APPTYPE, COMTYPE, DLLTYPE, DLLMODULETYPE, EXETYPE, EXEMODUL
 
 enum {VS2010, VS2012, VS2013, VS2015, VS2017, VS2019};
 
-#define VSLATEST VS2019
+#define VSEARLIEST VS2010
 
 enum {Q8, Q16, Q32, Q64};
 
@@ -146,7 +146,7 @@ static inline int parseVisualStudioVersion(const wstring &version)
   else if (version == L"2019")
     return(VS2019);
 
-  return(VSLATEST);
+  return(VSEARLIEST);
 }
 
 static inline bool isValidSrcFile(const wstring &fileName)


### PR DESCRIPTION
Due to latest changes the default Visual Studio version is latest VS2019 unless version is overridden by individual module settings.
This commit changes default to earliest supported VS release.